### PR TITLE
DDST-728: Add in `no-cache` cache control directive.

### DIFF
--- a/iiif_presentation_api.services.yml
+++ b/iiif_presentation_api.services.yml
@@ -54,3 +54,8 @@ services:
     class: Drupal\iiif_presentation_api\FieldMapper
     tags:
       - { name: iiif_presentation_api_mapper, base: iiif_presentation_api_map, version: v3 }
+
+  iiif_presentation_api.revalidation_directive_subscriber:
+    class: Drupal\iiif_presentation_api\EventSubscriber\RevalidationDirective
+    tags:
+      - { name: event_subscriber }

--- a/src/Controller/V3/ManifestController.php
+++ b/src/Controller/V3/ManifestController.php
@@ -8,6 +8,7 @@ use Drupal\Core\Controller\ControllerBase;
 use Drupal\Core\Render\RenderContext;
 use Drupal\Core\Render\RendererInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
+use Drupal\iiif_presentation_api\EventSubscriber\RevalidationDirective;
 use Drupal\serialization\Normalizer\CacheableNormalizerInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\Serializer\SerializerInterface;
@@ -63,7 +64,7 @@ class ManifestController extends ControllerBase {
         CacheableNormalizerInterface::SERIALIZATION_CONTEXT_CACHEABILITY => $cache_meta,
       ];
       $serialized = $this->serializer->serialize($_entity, 'iiif-p-v3', $context);
-      return (new CacheableJsonResponse(
+      $response = (new CacheableJsonResponse(
         $serialized,
         200,
         [
@@ -73,6 +74,10 @@ class ManifestController extends ControllerBase {
         ],
         TRUE
       ))->addCacheableDependency($cache_meta);
+
+      $response->headers->set(RevalidationDirective::HEADER, TRUE);
+
+      return $response;
     });
 
     if (!$context->isEmpty()) {

--- a/src/EventSubscriber/RevalidationDirective.php
+++ b/src/EventSubscriber/RevalidationDirective.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Drupal\iiif_presentation_api\EventSubscriber;
+
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\HttpKernel\Event\ResponseEvent;
+use Symfony\Component\HttpKernel\KernelEvents;
+
+/**
+ * Add 'must_revalidate' to IIIF-P manifests, for access control responsiveness.
+ */
+class RevalidationDirective implements EventSubscriberInterface {
+
+  const HEADER = 'X-iiif_presentation_api_revalidate';
+
+  /**
+   * {@inheritDoc}
+   */
+  public static function getSubscribedEvents() : array {
+    return [
+      KernelEvents::RESPONSE => [['doRevalidation', -10]],
+    ];
+  }
+
+  /**
+   * Event callback; add in 'must_revalidate' for our controller response.
+   *
+   * @param \Symfony\Component\HttpKernel\Event\ResponseEvent $event
+   *   The response on which to act.
+   */
+  public function doRevalidation(ResponseEvent $event) : void {
+    $response = $event->getResponse();
+
+    if (!$response->headers->has(static::HEADER)) {
+      return;
+    }
+
+    $response->headers->remove(static::HEADER);
+
+    if ($response->isCacheable()) {
+      $response->setCache(['must_revalidate' => TRUE]);
+    }
+  }
+
+}

--- a/src/EventSubscriber/RevalidationDirective.php
+++ b/src/EventSubscriber/RevalidationDirective.php
@@ -7,7 +7,10 @@ use Symfony\Component\HttpKernel\Event\ResponseEvent;
 use Symfony\Component\HttpKernel\KernelEvents;
 
 /**
- * Add 'must_revalidate' to IIIF-P manifests, for access control responsiveness.
+ * Add 'Cache-Control: no-cache' to IIIF-P manifests.
+ *
+ * So access control actions should take effect sooner, at the expense of more
+ * load on the server during general use.
  */
 class RevalidationDirective implements EventSubscriberInterface {
 
@@ -38,7 +41,7 @@ class RevalidationDirective implements EventSubscriberInterface {
     $response->headers->remove(static::HEADER);
 
     if ($response->isCacheable()) {
-      $response->setCache(['must_revalidate' => TRUE]);
+      $response->setCache(['no_cache' => TRUE]);
     }
   }
 

--- a/src/EventSubscriber/RevalidationDirective.php
+++ b/src/EventSubscriber/RevalidationDirective.php
@@ -9,8 +9,13 @@ use Symfony\Component\HttpKernel\KernelEvents;
 /**
  * Add 'Cache-Control: no-cache' to IIIF-P manifests.
  *
- * So access control actions should take effect sooner, at the expense of more
- * load on the server during general use.
+ * This is done such that access control actions should take effect sooner, at
+ * the expense of more load on the server during general use.
+ *
+ * Note: This is explicitly weighted/prioritized such that it should run _after_
+ * Drupal's `FinishResponseSubscriber` runs to add its base cache headers.
+ *
+ * @see \Drupal\Core\EventSubscriber\FinishResponseSubscriber::getSubscribedEvents()
  */
 class RevalidationDirective implements EventSubscriberInterface {
 

--- a/src/EventSubscriber/V3/BaseImageBodyEventSubscriber.php
+++ b/src/EventSubscriber/V3/BaseImageBodyEventSubscriber.php
@@ -16,7 +16,7 @@ class BaseImageBodyEventSubscriber implements EventSubscriberInterface {
    * Constructor.
    */
   public function __construct(
-    protected PluginManagerInterface $idPluginManager
+    protected PluginManagerInterface $idPluginManager,
   ) {
   }
 


### PR DESCRIPTION
Something of a trade off between access control responsiveness and server processing load.